### PR TITLE
handle --without-x properly

### DIFF
--- a/xpdf/Makefile.in
+++ b/xpdf/Makefile.in
@@ -124,7 +124,7 @@ all: $(LIBPREFIX)Xpdf.a xpdf$(EXE) pdftops$(EXE) pdftotext$(EXE) pdftohtml$(EXE)
 	pdftopng$(EXE) pdfimages$(EXE)
 
 all-no-x: $(LIBPREFIX)Xpdf.a pdftops$(EXE) pdftotext$(EXE) pdftohtml$(EXE) pdfinfo$(EXE) \
-	pdffonts$(EXE) pdfdetach$(EXE) pdfimages$(EXE)
+	pdffonts$(EXE) pdfdetach$(EXE) pdfimages$(EXE) pdftopng$(EXE)
 
 #------------------------------------------------------------------------
 
@@ -174,10 +174,6 @@ XPDF_LIB_OBJS = \
 	UnicodeMap.o \
 	UnicodeTypeTable.o \
 	XFAForm.o \
-	XPDFApp.o \
-	XPDFCore.o \
-	XPDFTree.o \
-	XPDFViewer.o \
 	XpdfPluginAPI.o \
 	XRef.o \
 	Zoox.o


### PR DESCRIPTION
The current list of objects for libXpdf.a includes the objects for the GUI application.  I'd suggest that they should never be part of libXpdf.a.  Removing them allows building with the "--without-x" configuration flag to succeed.  Additionally, the pdftopng executable doesn't depend on X Windows, and is useful, so should be built even in the "--without-x" case.